### PR TITLE
Add the missing writeup link

### DIFF
--- a/posts/the-definitive-guide-to-the-javascript-generators/index.md
+++ b/posts/the-definitive-guide-to-the-javascript-generators/index.md
@@ -540,7 +540,7 @@ There are several existing libraries that implement a variation of the above con
 
 ## Further Reading
 
-[Exploring ES6](http://exploringjs.com/) has a chapter about [Generators](http://exploringjs.com/es6/ch_generators.html). [Axel Rauschmayer](https://twitter.com/rauschma) write up about generators covers a lot more than I managed to cover in this article. It is a lengthy read, though I thoroughly recommend it.
+[Exploring ES6](http://exploringjs.com/) has a chapter about [Generators](http://exploringjs.com/es6/ch_generators.html). [Axel Rauschmayer](https://twitter.com/rauschma) [write up](http://2ality.com/2015/03/es6-generators.html) about generators covers a lot more than I managed to cover in this article. It is a lengthy read, though I thoroughly recommend it.
 
 * https://github.com/jmar777/suspend
 * https://github.com/visionmedia/co


### PR DESCRIPTION
Add the missing writeup link on generators by Axel Rauschmayer. Right now, link is provided only for the author's twitter profile.